### PR TITLE
feat: add traced svg placeholders to people; tweak header

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -88,6 +88,17 @@ const NavigationItem = styled.li({
   }),
 });
 
+const SecondaryLinks = styled.div({
+  display: 'flex',
+  justifyContent: 'space-between',
+  width: '100%',
+  margin: '0 auto',
+  ...DIMENSIONS.greaterThan('large')({
+    padding: '0 2.5rem',
+    width: '80%',
+  }),
+});
+
 const IndexLink = styled(GatsbyLink)({
   textDecoration: 'none',
 });
@@ -170,11 +181,15 @@ export default function HeaderComponent({ location }) {
               <Image fixed={data.logo.image.fixed} />
             </IndexLink>
             <NavigationList>
-              {data.site.siteMetadata.navigationItems.map(({ href, label }) => (
-                <NavigationItem key={href}>
-                  <Link to={href}>{label}</Link>
-                </NavigationItem>
-              ))}
+              <SecondaryLinks>
+                {data.site.siteMetadata.navigationItems.map(
+                  ({ href, label }) => (
+                    <NavigationItem key={href}>
+                      <Link to={href}>{label}</Link>
+                    </NavigationItem>
+                  )
+                )}
+              </SecondaryLinks>
               <NavigationItem>
                 <AttendLink to="/attend">Attend</AttendLink>
               </NavigationItem>

--- a/src/components/speaker.js
+++ b/src/components/speaker.js
@@ -153,7 +153,7 @@ export const speakerFragment = graphql`
     id
     avatar {
       fixed(height: 250, width: 250) {
-        ...GatsbyContentfulFixed_withWebp
+        ...GatsbyContentfulFixed_tracedSVG
       }
     }
     name


### PR DESCRIPTION
This PR enables traced SVG placeholders and tweaks the header a bit so it looks less "wide" on larger desktops.